### PR TITLE
write CRC after single block

### DIFF
--- a/sdcard.c
+++ b/sdcard.c
@@ -332,10 +332,11 @@ uint8_t SD_writeSingleBlock(uint32_t addr, uint8_t *buf, uint8_t *token)
         // write buffer to card
         for(uint16_t i = 0; i < SD_BLOCK_LEN; i++) SPI_transfer(buf[i]);
 
-        // wait for a response (timeout = 250ms)
-        readAttempts = 0;
-        while(++readAttempts != SD_MAX_WRITE_ATTEMPTS)
-            if((read = SPI_transfer(0xFF)) != 0xFF) { *token = 0xFF; break; }
+        // write CRC
+        SPI_transfer(0xFF); SPI_transfer(0xFF);
+
+        // read response
+        read = SPI_transfer(0xFF);
 
         // if data accepted
         if((read & 0x1F) == 0x05)


### PR DESCRIPTION
From what I understand, the card is supposed to respond with a data_response directly after a data block + CRC. The standard doesn't make it perfectly clear that a CRC is always needed.

Might be a good idea to also update your excellent AVR C tutorial here as well: http://www.rjhcoding.com/avrc-sd-interface-4.php